### PR TITLE
Add renderer class, speed up cactus velocity and increase dino jump

### DIFF
--- a/lib/cactus.js
+++ b/lib/cactus.js
@@ -3,7 +3,7 @@ const Block = require('./block');
 class Cactus extends Block {
   constructor(options) {
     super(options)
-    this.velocity = 2
+    this.velocity = 4
 
   }
 

--- a/lib/dino.js
+++ b/lib/dino.js
@@ -70,7 +70,7 @@ class Dino extends Block {
 
   jump() {
     if (this.jumpAvailable) {
-      this.velocity = -15;
+      this.velocity = -20;
     }
   }
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,33 @@
+class Renderer {
+
+  constructor(game) {
+    this.cacti = game.cacti;
+    this.dino = game.dino;
+    this.canvas = game.canvas;
+    this.context = game.context;
+  }
+
+  draw() {
+    this.drawDino();
+    this.drawCacti();
+  }
+
+  drawDino() {
+    this.drawObject(this.dino);
+    return this;
+  }
+
+  drawCacti() {
+    let that = this;
+    this.cacti.forEach(function (cactus) {
+      that.drawObject(cactus)
+    })
+  }
+
+  drawObject(object) {
+    this.context.drawImage(object.image, object.x, object.y, object.width, object.height);
+    return this;
+  }
+}
+
+module.exports = Renderer;

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,6 +1,7 @@
 const Cactus = require('./cactus')
 const Dino = require('./dino')
 const Collision = require('./collision')
+const Renderer = require('./renderer')
 let dinoSprite = new Image();
 dinoSprite.src = './images/trex.png'
 let cactus1 = new Image();
@@ -31,6 +32,7 @@ class Session {
       new Cactus({image: cactus2, x: 1350, y: 235, width: 25, height: 65})
     ];
     this.Collision = new Collision(this.dino, this.cacti)
+    this.renderer = new Renderer(this)
   };
 
   tick() {
@@ -39,7 +41,7 @@ class Session {
       this.context.clearRect(0, 0, this.canvas.width, this.canvas.height)
       if (this.dino.isFalling || this.dino.isAtCrestOfJump) this.dino.activateGravity();
       if (this.dino.isJumping) this.dino.executeJump();
-      this.draw();
+      this.renderer.draw();
       if (this.Collision.dinoHit()) this.active = false
       this.update();
     } else {
@@ -55,27 +57,27 @@ class Session {
     })
   }
 
-  draw() {
-    this.drawDino();
-    this.drawCacti();
-  }
-
-  drawDino() {
-    this.drawObject(this.dino);
-    return this;
-  }
-
-  drawCacti() {
-    let that = this;
-    this.cacti.forEach(function (cactus) {
-      that.drawObject(cactus)
-    })
-  }
-
-  drawObject(object) {
-    this.context.drawImage(object.image, object.x, object.y, object.width, object.height);
-    return this;
-  }
+  // draw() {
+  //   this.drawDino();
+  //   this.drawCacti();
+  // }
+  //
+  // drawDino() {
+  //   this.drawObject(this.dino);
+  //   return this;
+  // }
+  //
+  // drawCacti() {
+  //   let that = this;
+  //   this.cacti.forEach(function (cactus) {
+  //     that.drawObject(cactus)
+  //   })
+  // }
+  //
+  // drawObject(object) {
+  //   this.context.drawImage(object.image, object.x, object.y, object.width, object.height);
+  //   return this;
+  // }
 }
 
 module.exports = Session;

--- a/test/cactus-test.js
+++ b/test/cactus-test.js
@@ -30,10 +30,10 @@ describe("Cactus", function(){
     assert.equal(cactus.width, 10);
   });
 
-  it("instantiates with a velocity of 2", function(){
+  it("instantiates with a velocity of 4", function(){
     let cactus = new Cactus(options);
 
-    assert.equal(cactus.velocity, 2);
+    assert.equal(cactus.velocity, 4);
   });
 
   it("can resurrect itself off to the right of the canvas width", function() {

--- a/test/dino-test.js
+++ b/test/dino-test.js
@@ -120,7 +120,7 @@ describe("Dino", function(){
     let dino = new Dino(options);
     dino.jump();
 
-    assert.equal(dino.velocity, -15);
+    assert.equal(dino.velocity, -20);
     assert.isTrue(dino.isJumping);
   });
 


### PR DESCRIPTION
Added renderer class to complete all canvas drawing methods.
Also sped up cacti so that it was easier to jump over them and increased dino jump initial velocity to make it easier to jump while testing visually. We can bring those back down if we need to when we're closer to deploying.
